### PR TITLE
Fix Exception Try/Catch

### DIFF
--- a/src/main/java/explorer/engine/MainEngine.java
+++ b/src/main/java/explorer/engine/MainEngine.java
@@ -1,6 +1,5 @@
 package explorer.engine;
 
-import java.io.IOException;
 import java.io.InputStream;
 import java.sql.Timestamp;
 import java.util.Properties;
@@ -36,7 +35,7 @@ public class MainEngine {
 			// load local properties file
 			prop.load(local);
 
-		} catch(IOException e){
+		} catch(Exception e){
 			InputStream global = MainEngine.class.getClassLoader().getResourceAsStream("global.properties");
 			// load global properties file
 			prop.load(global);


### PR DESCRIPTION
Fix for Exception not being caught when "local.properties" file doesn't exist.
```
Starting Analysis: 2019-01-07 11:08:58.043
Exception in thread "main" java.lang.NullPointerException
	at java.util.Properties$LineReader.readLine(Unknown Source)
	at java.util.Properties.load0(Unknown Source)
	at java.util.Properties.load(Unknown Source)
	at explorer.engine.MainEngine.<init>(MainEngine.java:37)
	at explorer.engine.MainEngine.main(MainEngine.java:106)
```